### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/twnk/quocktail/compare/v0.1.2...v0.1.3) - 2024-02-18
+
+### Fixed
+- try again?
+
+### Other
+- Merge branch 'main' of github.com:twnk/quocktail
+
 ## [0.1.2](https://github.com/twnk/quocktail/compare/v0.1.1...v0.1.2) - 2024-02-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "quocktail"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quocktail"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Rust CLI for searching through nested directories of markdown files with frontmatter, filtering and displaying the results"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## 🤖 New release
* `quocktail`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/twnk/quocktail/compare/v0.1.2...v0.1.3) - 2024-02-18

### Fixed
- try again?

### Other
- Merge branch 'main' of github.com:twnk/quocktail
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).