### PR TITLE
chore: release v0.1.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@
 # * uploads those artifacts to temporary workflow zip
 # * on success, uploads the artifacts to a Github Release
 #
-# Note that the Github Release will be created with a generated
-# title/body based on your changelogs.
+# Note that a Github Release with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 
 name: Release
 
@@ -297,7 +297,9 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.plan.outputs.tag }}
-          name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
-          body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
           prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/twnk/quocktail/compare/v0.1.3...v0.1.4) - 2024-02-18
+
+### Fixed
+- release plz plz plz plz?
+
+### Other
+- Merge branch 'main' of github.com:twnk/quocktail
+
 ## [0.1.3](https://github.com/twnk/quocktail/compare/v0.1.2...v0.1.3) - 2024-02-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "quocktail"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quocktail"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Rust CLI for searching through nested directories of markdown files with frontmatter, filtering and displaying the results"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## 🤖 New release
* `quocktail`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/twnk/quocktail/compare/v0.1.3...v0.1.4) - 2024-02-18

### Fixed
- release plz plz plz plz?

### Other
- Merge branch 'main' of github.com:twnk/quocktail
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).