### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/twnk/quocktail/compare/v0.1.5...v0.1.6) - 2024-03-17
+
+### Added
+- rewrite parser entirely, handle or
+
+### Fixed
+- formatting
+
+### Other
+- Merge pull request [#7](https://github.com/twnk/quocktail/pull/7) from twnk/feat/nested-ingredients
+
 ## [0.1.5](https://github.com/twnk/quocktail/compare/v0.1.4...v0.1.5) - 2024-02-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "quocktail"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quocktail"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Rust CLI for searching through nested directories of markdown files with frontmatter, filtering and displaying the results"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## 🤖 New release
* `quocktail`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/twnk/quocktail/compare/v0.1.5...v0.1.6) - 2024-03-17

### Added
- rewrite parser entirely, handle or

### Fixed
- formatting

### Other
- Merge pull request [#7](https://github.com/twnk/quocktail/pull/7) from twnk/feat/nested-ingredients
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).